### PR TITLE
Fix max_epochs in range loop of training task

### DIFF
--- a/train.py
+++ b/train.py
@@ -171,7 +171,7 @@ def main():
     else:
         starting_epoch = 1
 
-    for epoch in range(starting_epoch, args.max_epochs):
+    for epoch in range(starting_epoch, args.max_epochs + 1):
         logger.info('Current learning rate %.8f' % get_lr(task.optimizer))
 
         if hasattr(train_iter, 'init_epoch'):


### PR DESCRIPTION
Hi there,

Although this is a very minor thing, the `max_epochs` argument seems not being implemented correctly. Since `starting_epoch` is set to 1, in training `range()` loop, the stop condition should be `max_epochs+1`, or the training task would only run for `max_epochs-1` epochs. And no training task executed for `max_epochs = 1`.

Thanks a lot for the great implementation of DME, learnt a lot from your research and code!

Best regards,
Mark